### PR TITLE
Allow additional missing elements

### DIFF
--- a/src/entry.rs
+++ b/src/entry.rs
@@ -91,7 +91,7 @@ impl FromXml for Entry {
 
         let updated = match elem.get_child("updated", Some(NS)) {
             Some(elem) => elem.content_str(),
-            None => return Err("<entry> is missing required <updated> element"),
+            None => String::new(),
         };
 
         let source = try!(elem.get_child("source", Some(NS))

--- a/src/feed.rs
+++ b/src/feed.rs
@@ -87,7 +87,7 @@ impl FromXml for Feed {
     fn from_xml(elem: &Element) -> Result<Self, &'static str> {
         let id = match elem.get_child("id", Some(NS)) {
             Some(elem) => elem.content_str(),
-            None => return Err("<feed> is missing required <id> element"),
+            None => String::new(),
         };
 
         let title = match elem.get_child("title", Some(NS)) {


### PR DESCRIPTION
With this PR, missing `feed > id` and `entry > updated` elements are no longer hard errors and are instead set to empty String.